### PR TITLE
remove stale referenct to mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ config = {
         'Programming Language :: Python :: 3',
     ],
     'install_requires': requirements,
-    'tests_require': ['nose', 'mock'],
+    'tests_require': ['nose'],
     'test_suite': 'nose.collector',
     'packages': find_packages(),
     'include_package_data': True,


### PR DESCRIPTION
here mock is not even used at all

---

https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.